### PR TITLE
[extension] User game stats

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,8 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require jquery
+//= require jquery_ujs 
 //= require rails-ujs
 //= require activestorage
 //= require_tree .

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,3 +25,7 @@ body {
 nav {
   background-color: #fc3c3b;
 }
+
+#stats-table {
+  text-align: center;
+}

--- a/app/controllers/games_score_controller.rb
+++ b/app/controllers/games_score_controller.rb
@@ -1,0 +1,6 @@
+class GamesScoreController < ApplicationController
+  def destroy
+    current_user.game_score.delete_all
+    redirect_to profile_path
+  end
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,5 +1,5 @@
 class Game < ApplicationRecord
   validates_presence_of :category, :difficulty, :number_of_questions, :custom_name
   belongs_to :user
-  has_many :game_score
+  has_many :game_score, :dependent => :destroy
 end

--- a/app/models/game_score.rb
+++ b/app/models/game_score.rb
@@ -1,4 +1,20 @@
 class GameScore < ApplicationRecord
   belongs_to :game
   belongs_to :user
+
+  def game_id
+    game.id
+  end
+
+  def game_name
+    game.custom_name
+  end
+
+  def game_total_questions
+    game.number_of_questions
+  end
+
+  def game_percent_score
+    score / game_total_questions.to_f * 100
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   validates_presence_of :username, :email
   has_many :games
-  has_many :game_score
+  has_many :game_score, :dependent => :destroy
 
   def self.from_omniauth(auth)
     where(email: auth.info.email).first_or_initialize do |user|
@@ -11,6 +11,6 @@ class User < ApplicationRecord
   end
 
   def total_games_played
-    games.count
+    game_score.count
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,8 @@ class User < ApplicationRecord
       user.email = auth.info.email
     end
   end
+
+  def total_games_played
+    games.count
+  end
 end

--- a/app/views/games/new.html.erb
+++ b/app/views/games/new.html.erb
@@ -2,7 +2,7 @@
 
 <center>
   <%= form_tag "/games", method: :post do %>
-    <%= label_tag "Customer name:" %>
+    <%= label_tag "Custom name:" %>
     <%= text_field_tag :custom_name, nil, placeholder: "Name" %> <br>
     <%= label_tag "Total Number of Trivia Questions:" %>
     <%= select_tag(:number_of_questions, options_for_select(questions), {class: "select-field"}) %><br>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,10 +1,37 @@
+<div class="container" id="stats-table">
+  <h4><%= @user.username %>'s Game Stats</h4>
+  <br>
+  <section class='game-stats'>
+    <table class="table table-bordered">
+      <thead class="text-center thead-light">
+        <tr>
+          <th style="width: 20%;">Game Name</th>
+          <th>My Score</th>
+          <th>Total # of Questions</th>
+          <th>% Score</th>
+        </tr>
+      </thead>
+      <tbody class="text-center">
+        <% @user.game_score.each do |stat| %>
+        <tr id='game-<%= stat.game_id %>'>
+          <td>
+            <%= stat.game_name %>
+          </td>
+          <td>
+            <%= stat.score %>
+          </td>
+          <td>
+            <%= stat.game_total_questions %>
+          </td>
+          <td>
+            <%= stat.game_percent_score.round(2) %>
+          </td>
+        </tr>
+        <% end %>
+      </tbody>
+    </table>
 
-<%= @user.username %>
-
-<h4>Your Game Stats</h4>
-
-<h4>Number of Games Played</h4>
-
-<h4>Number of Games Won</h4>
-
-<h4>Number of Correctly Answered Questions</h4>
+    <p class='total-games-played'><strong>Total Games Played: <%= @user.total_games_played %></strong></p>
+    <hr>
+  </section>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,6 +2,15 @@
   <h4><%= @user.username %>'s Game Stats</h4>
   <br>
   <section class='game-stats'>
+    
+    <p class='total-games-played'><strong>Total Games Played: <%= @user.total_games_played %></strong></p>
+    <section class='clear-stats'>
+      <% unless @user.games.empty? %>
+        <%= link_to "Delete all", "/profile/clear_stats", method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-primary' %>
+      <% end %>
+    </section>
+    <br>
+
     <table class="table table-bordered">
       <thead class="text-center thead-light">
         <tr>
@@ -30,8 +39,5 @@
         <% end %>
       </tbody>
     </table>
-
-    <p class='total-games-played'><strong>Total Games Played: <%= @user.total_games_played %></strong></p>
-    <hr>
   </section>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,8 +14,7 @@ Rails.application.routes.draw do
   get "/auth/:provider/callback", to: "sessions#googleAuth"
   get "/auth/failure", to: redirect("/")
   get "/profile", to: "users#show"
-
+  delete "/profile/clear_stats", to: "games_score#destroy"
 
   resources :games, only:[:index, :destroy]
-
 end

--- a/spec/features/users/user/user_can_access_their_profile_page_spec.rb
+++ b/spec/features/users/user/user_can_access_their_profile_page_spec.rb
@@ -1,16 +1,21 @@
 require 'rails_helper'
 
 describe 'A registered user' do
-  it 'can see all tutorials marked for both classroom and non-classroom purposes' do
-    user = User.create!(username: "JoshSherwood1", email: "email@email.com", google_token: "yadayada")
-
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
-
+  before(:each) do
+    @user = User.create!(username: "JoshSherwood1", email: "email@email.com", google_token: "yadayada")
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
     visit "/profile"
-    expect(page).to have_content("Game Stats")
-    expect(page).to have_content("Number of Games Played")
-    expect(page).to have_content("Number of Games Won")
-    expect(page).to have_content("Number of Correctly Answered Questions")
-    expect(page).to have_content("JoshSherwood1")
+  end
+
+  it 'can see their profile page' do
+    expect(page).to have_content("#{@user.username}'s Game Stats")
+
+    within '.game-stats' do
+      expect(page).to have_content("Game Name")
+      expect(page).to have_content("My Score")
+      expect(page).to have_content("Total # of Questions")
+      expect(page).to have_content("% Score")
+      expect(page).to have_content("Total Games Played: 0")
+    end
   end
 end

--- a/spec/features/users/user/user_can_see_their_game_stats_spec.rb
+++ b/spec/features/users/user/user_can_see_their_game_stats_spec.rb
@@ -1,19 +1,21 @@
 require 'rails_helper'
 
 describe 'A registered user' do
-  it 'can see my game stats on my profile page' do
+  before(:each) do
     user = User.create!(username: "JoshSherwood1", email: "email@email.com", google_token: "yadayada")
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
-    game_1 = user.games.create!(custom_name: "GeoTime", category: "Geography", number_of_questions: "5", difficulty: "easy", user: user)
-    game_score_1 = user.game_score.create!(game: game_1, user: user, score: 3)
+    @game_1 = user.games.create!(custom_name: "GeoTime", category: "Geography", number_of_questions: "5", difficulty: "easy", user: user)
+    @game_score_1 = user.game_score.create!(game: @game_1, user: user, score: 3)
 
-    game_2 = user.games.create!(custom_name: "HistoryTime", category: "History", number_of_questions: "7", difficulty: "medium", user: user)
-    game_score_2 = user.game_score.create!(game: game_2, user: user, score: 7)
+    @game_2 = user.games.create!(custom_name: "HistoryTime", category: "History", number_of_questions: "7", difficulty: "medium", user: user)
+    @game_score_2 = user.game_score.create!(game: @game_2, user: user, score: 7)
 
-    game_3 = user.games.create!(custom_name: "MathTime", category: "Math", number_of_questions: "9", difficulty: "hard", user: user)
-    game_score_3 = user.game_score.create!(game: game_3, user: user, score: 7)
+    @game_3 = user.games.create!(custom_name: "MathTime", category: "Math", number_of_questions: "9", difficulty: "hard", user: user)
+    @game_score_3 = user.game_score.create!(game: @game_3, user: user, score: 7)
+  end
 
+  it 'can see my game stats on my profile page' do
     visit "/profile"
 
     within '.game-stats' do
@@ -22,30 +24,44 @@ describe 'A registered user' do
       expect(page).to have_content("Total # of Questions")
       expect(page).to have_content("% Score")
 
-      within "#game-#{game_1.id}" do
-        expect(page).to have_content(game_1.custom_name)
-        expect(page).to have_content(game_1.number_of_questions)
-        expect(page).to have_content(game_score_1.score)
+      within "#game-#{@game_1.id}" do
+        expect(page).to have_content(@game_1.custom_name)
+        expect(page).to have_content(@game_1.number_of_questions)
+        expect(page).to have_content(@game_score_1.score)
         expect(page).to have_content('60.0')
       end
 
-      within "#game-#{game_2.id}" do
-        expect(page).to have_content(game_2.custom_name)
-        expect(page).to have_content(game_2.number_of_questions)
-        expect(page).to have_content(game_score_2.score)
+      within "#game-#{@game_2.id}" do
+        expect(page).to have_content(@game_2.custom_name)
+        expect(page).to have_content(@game_2.number_of_questions)
+        expect(page).to have_content(@game_score_2.score)
         expect(page).to have_content('100.0')
       end
 
-      within "#game-#{game_3.id}" do
-        expect(page).to have_content(game_3.custom_name)
-        expect(page).to have_content(game_3.number_of_questions)
-        expect(page).to have_content(game_score_3.score)
+      within "#game-#{@game_3.id}" do
+        expect(page).to have_content(@game_3.custom_name)
+        expect(page).to have_content(@game_3.number_of_questions)
+        expect(page).to have_content(@game_score_3.score)
         expect(page).to have_content('77.78')
       end
 
       within '.total-games-played' do
         expect(page).to have_content("Total Games Played: 3")
       end
+    end
+  end
+
+  it "can delete all game stats" do
+    visit "/profile"
+
+    within '.game-stats' do
+      click_on "Delete all"
+    end
+
+    within '.clear-stats' do
+      expect(page).to_not have_css("#game-#{@game_1.id}")
+      expect(page).to_not have_css("#game-#{@game_2.id}")
+      expect(page).to_not have_css("#game-#{@game_3.id}")
     end
   end
 end

--- a/spec/features/users/user/user_can_see_their_game_stats_spec.rb
+++ b/spec/features/users/user/user_can_see_their_game_stats_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+describe 'A registered user' do
+  it 'can see my game stats on my profile page' do
+    user = User.create!(username: "JoshSherwood1", email: "email@email.com", google_token: "yadayada")
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    game_1 = user.games.create!(custom_name: "GeoTime", category: "Geography", number_of_questions: "5", difficulty: "easy", user: user)
+    game_score_1 = user.game_score.create!(game: game_1, user: user, score: 3)
+
+    game_2 = user.games.create!(custom_name: "HistoryTime", category: "History", number_of_questions: "7", difficulty: "medium", user: user)
+    game_score_2 = user.game_score.create!(game: game_2, user: user, score: 7)
+
+    game_3 = user.games.create!(custom_name: "MathTime", category: "Math", number_of_questions: "9", difficulty: "hard", user: user)
+    game_score_3 = user.game_score.create!(game: game_3, user: user, score: 7)
+
+    visit "/profile"
+
+    within '.game-stats' do
+      expect(page).to have_content("Game Name")
+      expect(page).to have_content("My Score")
+      expect(page).to have_content("Total # of Questions")
+      expect(page).to have_content("% Score")
+
+      within "#game-#{game_1.id}" do
+        expect(page).to have_content(game_1.custom_name)
+        expect(page).to have_content(game_1.number_of_questions)
+        expect(page).to have_content(game_score_1.score)
+        expect(page).to have_content('60.0')
+      end
+
+      within "#game-#{game_2.id}" do
+        expect(page).to have_content(game_2.custom_name)
+        expect(page).to have_content(game_2.number_of_questions)
+        expect(page).to have_content(game_score_2.score)
+        expect(page).to have_content('100.0')
+      end
+
+      within "#game-#{game_3.id}" do
+        expect(page).to have_content(game_3.custom_name)
+        expect(page).to have_content(game_3.number_of_questions)
+        expect(page).to have_content(game_score_3.score)
+        expect(page).to have_content('77.78')
+      end
+
+      within '.total-games-played' do
+        expect(page).to have_content("Total Games Played: 3")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the following:
- a table containing the current user's game stats (i.e., `raw score`, `total_number_of_questions`, `percent_score`)
- a `delete all` button to clear game stats 
  - working on make it a conditional display, such that the button only appears when the user actually created && completed a game